### PR TITLE
Github action to build and push to Public ECR

### DIFF
--- a/.github/workflows/push-mpc-to-ecr.yml
+++ b/.github/workflows/push-mpc-to-ecr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
-          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
           # Build a docker container and

--- a/.github/workflows/push-mpc-to-ecr.yml
+++ b/.github/workflows/push-mpc-to-ecr.yml
@@ -1,0 +1,48 @@
+name: Build & Push MPC Signer to Amazon ECR
+
+on:
+  push:
+    branches: [ "matt/feature/mpc-signer" ]
+
+env:
+  AWS_ROLE_ARN: arn:aws:iam::961171757719:role/GithubActions-ECRPublicPowerUser
+  AWS_REGION: global
+  ECR_REPOSITORY: mpc-firefly-signer
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Build a docker container and
+          # push it to ECR so that it can
+          # be deployed to ECS.
+          docker buildx build --platform linux/amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/push-mpc-to-ecr.yml
+++ b/.github/workflows/push-mpc-to-ecr.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   AWS_ROLE_ARN: arn:aws:iam::961171757719:role/GithubActions-ECRPublicPowerUser
-  AWS_REGION: global
+  AWS_REGION: us-east-1
   ECR_REPOSITORY: mpc-firefly-signer
 
 permissions:
@@ -14,10 +14,10 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 jobs:
-  deploy:
-    name: Deploy
+  push-to-ecr:
+    name: Push to ECR
     runs-on: ubuntu-latest
-    environment: production
+    environment: dev
 
     steps:
       - name: Checkout

--- a/.github/workflows/push-mpc-to-ecr.yml
+++ b/.github/workflows/push-mpc-to-ecr.yml
@@ -24,20 +24,22 @@ jobs:
         uses: actions/checkout@v3
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
           # Build a docker container and

--- a/.github/workflows/push-mpc-to-ecr.yml
+++ b/.github/workflows/push-mpc-to-ecr.yml
@@ -1,51 +1,70 @@
+# Builds and pushes MPC Signer to Amazon ECR. Relies on an OIDC identity provider to authenticate to AWS. Role used
+# must have permissions to publish to public ECR.
+
 name: Build & Push MPC Signer to Amazon ECR
 
 on:
-  push:
-    branches: [ "matt/feature/mpc-signer" ]
+  # Run if PR is merged to feature/mpc-signer or main branches
+  pull_request:
+    branches: [ "feature/mpc-signer", "main" ]
+    types: [ closed ]
+  # Run manually
+  workflow_dispatch:
 
 env:
+  # AWS Role with permissions to publish to Pulbic ECR
   AWS_ROLE_ARN: arn:aws:iam::961171757719:role/GithubActions-ECRPublicPowerUser
+  # AWS Region
   AWS_REGION: us-east-1
+  # ECR Repository name
   ECR_REPOSITORY: mpc-firefly-signer
+  # ECR Repository alias (for public ECR)
   ECR_REGISTRY_ALIAS: f8q0b6a6
 
 permissions:
-  id-token: write   # This is required for requesting the JWT
-  contents: read    # This is required for actions/checkout
+  # Requests JWT for GitHub Actions to authenticate to AWS
+  id-token: write
+  # Requests read access to the repository
+  contents: read
 
 jobs:
-  push-to-ecr:
-    name: Push to ECR
+  build-and-push-to-ecr:
+    # Run if manually triggered or if PR is merged
+    if: ${{ github.event_name == "workflow_dispatch" || github.event.pull_request.merged }}
+    name: Build & Push to ECR
     runs-on: ubuntu-latest
-    environment: dev
+    # Set to "prod" environment if running on main branch, otherwise "dev"
+    environment: ${{ github.ref == "refs/heads/main" && "prod" || "dev" }}
 
     steps:
+      # Checkout the source
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: configure aws credentials
+      # Configure AWS credentials against from our OIDC identity provider
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Login to Amazon ECR Public
+      # Login to AWS ECR Public with our OIDC credentials
+      - name: Login to AWS ECR Public
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
 
-      - name: Build, tag, and push image to Amazon ECR
+      # Build as amd64 image, tag with sha and "latest", then push to ECR
+      - name: Build, tag, and push image to Amazon ECR Public
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          # Build a docker container and
-          # push it to ECR so that it can
-          # be deployed to ECS.
-          docker buildx build --platform linux/amd64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest .
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY --all-tags
+          docker buildx build --platform linux/amd64 \
+            --push \
+            -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest .
           echo "image=$ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/push-mpc-to-ecr.yml
+++ b/.github/workflows/push-mpc-to-ecr.yml
@@ -8,6 +8,7 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::961171757719:role/GithubActions-ECRPublicPowerUser
   AWS_REGION: us-east-1
   ECR_REPOSITORY: mpc-firefly-signer
+  ECR_REGISTRY_ALIAS: f8q0b6a6
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -45,6 +46,6 @@ jobs:
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.
-          docker buildx build --platform linux/amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          docker buildx build --platform linux/amd64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY --all-tags
+          echo "image=$ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage.txt
 .DS_Store
 __debug*
 .vscode/*.log
+*.idea
+*.iml

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/config_docs_generate_test.go
+++ b/cmd/config_docs_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/config_docs_generate_test.go
+++ b/cmd/config_docs_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/config_docs_test.go
+++ b/cmd/config_docs_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/config_docs_test.go
+++ b/cmd/config_docs_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/ffsigner/main.go
+++ b/ffsigner/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/ffsigner/main.go
+++ b/ffsigner/main.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpchandler.go
+++ b/internal/rpcserver/rpchandler.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpchandler.go
+++ b/internal/rpcserver/rpchandler.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpchandler_test.go
+++ b/internal/rpcserver/rpchandler_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpchandler_test.go
+++ b/internal/rpcserver/rpchandler_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpcprocessor.go
+++ b/internal/rpcserver/rpcprocessor.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpcprocessor.go
+++ b/internal/rpcserver/rpcprocessor.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpcprocessor_test.go
+++ b/internal/rpcserver/rpcprocessor_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/rpcprocessor_test.go
+++ b/internal/rpcserver/rpcprocessor_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/server.go
+++ b/internal/rpcserver/server.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/server.go
+++ b/internal/rpcserver/server.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/server_test.go
+++ b/internal/rpcserver/server_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/rpcserver/server_test.go
+++ b/internal/rpcserver/server_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signerconfig/signerconfig.go
+++ b/internal/signerconfig/signerconfig.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signerconfig/signerconfig.go
+++ b/internal/signerconfig/signerconfig.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signerconfig/signerconfig_test.go
+++ b/internal/signerconfig/signerconfig_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signerconfig/signerconfig_test.go
+++ b/internal/signerconfig/signerconfig_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signermsgs/en_api_translations.go
+++ b/internal/signermsgs/en_api_translations.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signermsgs/en_api_translations.go
+++ b/internal/signermsgs/en_api_translations.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signermsgs/en_error_messges.go
+++ b/internal/signermsgs/en_error_messges.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signermsgs/en_field_descriptions.go
+++ b/internal/signermsgs/en_field_descriptions.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/signermsgs/en_field_descriptions.go
+++ b/internal/signermsgs/en_field_descriptions.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abidecode.go
+++ b/pkg/abi/abidecode.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abidecode.go
+++ b/pkg/abi/abidecode.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abidecode_test.go
+++ b/pkg/abi/abidecode_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abidecode_test.go
+++ b/pkg/abi/abidecode_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abiencode.go
+++ b/pkg/abi/abiencode.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abiencode.go
+++ b/pkg/abi/abiencode.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abiencode_test.go
+++ b/pkg/abi/abiencode_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/abiencode_test.go
+++ b/pkg/abi/abiencode_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/inputparsing.go
+++ b/pkg/abi/inputparsing.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/inputparsing.go
+++ b/pkg/abi/inputparsing.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/inputparsing_test.go
+++ b/pkg/abi/inputparsing_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/inputparsing_test.go
+++ b/pkg/abi/inputparsing_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/outputserialization.go
+++ b/pkg/abi/outputserialization.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/outputserialization.go
+++ b/pkg/abi/outputserialization.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/outputserialization_test.go
+++ b/pkg/abi/outputserialization_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/outputserialization_test.go
+++ b/pkg/abi/outputserialization_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/signedi256.go
+++ b/pkg/abi/signedi256.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/signedi256.go
+++ b/pkg/abi/signedi256.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/signedi256_test.go
+++ b/pkg/abi/signedi256_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/signedi256_test.go
+++ b/pkg/abi/signedi256_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/typecomponents.go
+++ b/pkg/abi/typecomponents.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/typecomponents_test.go
+++ b/pkg/abi/typecomponents_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/abi/typecomponents_test.go
+++ b/pkg/abi/typecomponents_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/abi_to_typed_data.go
+++ b/pkg/eip712/abi_to_typed_data.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/abi_to_typed_data.go
+++ b/pkg/eip712/abi_to_typed_data.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/abi_to_typed_data_test.go
+++ b/pkg/eip712/abi_to_typed_data_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/abi_to_typed_data_test.go
+++ b/pkg/eip712/abi_to_typed_data_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/typed_data_v4.go
+++ b/pkg/eip712/typed_data_v4.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/typed_data_v4.go
+++ b/pkg/eip712/typed_data_v4.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/typed_data_v4_test.go
+++ b/pkg/eip712/typed_data_v4_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/eip712/typed_data_v4_test.go
+++ b/pkg/eip712/typed_data_v4_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethereum/ethereum.go
+++ b/pkg/ethereum/ethereum.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethereum/ethereum.go
+++ b/pkg/ethereum/ethereum.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/transaction.go
+++ b/pkg/ethsigner/transaction.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/transaction.go
+++ b/pkg/ethsigner/transaction.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/transaction_test.go
+++ b/pkg/ethsigner/transaction_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/transaction_test.go
+++ b/pkg/ethsigner/transaction_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/typed_data.go
+++ b/pkg/ethsigner/typed_data.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/typed_data.go
+++ b/pkg/ethsigner/typed_data.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/typed_data_test.go
+++ b/pkg/ethsigner/typed_data_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/typed_data_test.go
+++ b/pkg/ethsigner/typed_data_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/wallet.go
+++ b/pkg/ethsigner/wallet.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethsigner/wallet.go
+++ b/pkg/ethsigner/wallet.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/address.go
+++ b/pkg/ethtypes/address.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/address.go
+++ b/pkg/ethtypes/address.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © {{ YEAR }} {{ COMPANY }} Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/address.go
+++ b/pkg/ethtypes/address.go
@@ -1,4 +1,4 @@
-// Copyright © {{ YEAR }} {{ COMPANY }} Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/address_test.go
+++ b/pkg/ethtypes/address_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/address_test.go
+++ b/pkg/ethtypes/address_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexbytes.go
+++ b/pkg/ethtypes/hexbytes.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexbytes.go
+++ b/pkg/ethtypes/hexbytes.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © {{ YEAR }} {{ COMPANY }} Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexbytes.go
+++ b/pkg/ethtypes/hexbytes.go
@@ -1,4 +1,4 @@
-// Copyright © {{ YEAR }} {{ COMPANY }} Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexbytes_test.go
+++ b/pkg/ethtypes/hexbytes_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexbytes_test.go
+++ b/pkg/ethtypes/hexbytes_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexinteger.go
+++ b/pkg/ethtypes/hexinteger.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexinteger.go
+++ b/pkg/ethtypes/hexinteger.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © {{ YEAR }} {{ COMPANY }} Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexinteger.go
+++ b/pkg/ethtypes/hexinteger.go
@@ -1,4 +1,4 @@
-// Copyright © {{ YEAR }} {{ COMPANY }} Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexinteger_test.go
+++ b/pkg/ethtypes/hexinteger_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ethtypes/hexinteger_test.go
+++ b/pkg/ethtypes/hexinteger_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi.go
+++ b/pkg/ffi2abi/ffi.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi.go
+++ b/pkg/ffi2abi/ffi.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi_param_validator.go
+++ b/pkg/ffi2abi/ffi_param_validator.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi_param_validator.go
+++ b/pkg/ffi2abi/ffi_param_validator.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi_param_validator_test.go
+++ b/pkg/ffi2abi/ffi_param_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi_param_validator_test.go
+++ b/pkg/ffi2abi/ffi_param_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi_test.go
+++ b/pkg/ffi2abi/ffi_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffi2abi/ffi_test.go
+++ b/pkg/ffi2abi/ffi_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/config.go
+++ b/pkg/fswallet/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/config.go
+++ b/pkg/fswallet/config.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fslistener.go
+++ b/pkg/fswallet/fslistener.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fslistener.go
+++ b/pkg/fswallet/fslistener.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fslistener_test.go
+++ b/pkg/fswallet/fslistener_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fslistener_test.go
+++ b/pkg/fswallet/fslistener_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fswallet.go
+++ b/pkg/fswallet/fswallet.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fswallet.go
+++ b/pkg/fswallet/fswallet.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fswallet_test.go
+++ b/pkg/fswallet/fswallet_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fswallet/fswallet_test.go
+++ b/pkg/fswallet/fswallet_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/aes128ctr.go
+++ b/pkg/keystorev3/aes128ctr.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/aes128ctr.go
+++ b/pkg/keystorev3/aes128ctr.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/aes128ctr_test.go
+++ b/pkg/keystorev3/aes128ctr_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/aes128ctr_test.go
+++ b/pkg/keystorev3/aes128ctr_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/pbkdf2.go
+++ b/pkg/keystorev3/pbkdf2.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/pbkdf2_test.go
+++ b/pkg/keystorev3/pbkdf2_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/pbkdf2_test.go
+++ b/pkg/keystorev3/pbkdf2_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/scrypt.go
+++ b/pkg/keystorev3/scrypt.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/scrypt_test.go
+++ b/pkg/keystorev3/scrypt_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/scrypt_test.go
+++ b/pkg/keystorev3/scrypt_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/wallet.go
+++ b/pkg/keystorev3/wallet.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/wallet_test.go
+++ b/pkg/keystorev3/wallet_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/wallet_test.go
+++ b/pkg/keystorev3/wallet_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/walletfile.go
+++ b/pkg/keystorev3/walletfile.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/keystorev3/walletfile.go
+++ b/pkg/keystorev3/walletfile.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/decode.go
+++ b/pkg/rlp/decode.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/decode.go
+++ b/pkg/rlp/decode.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/decode_test.go
+++ b/pkg/rlp/decode_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/decode_test.go
+++ b/pkg/rlp/decode_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/encode.go
+++ b/pkg/rlp/encode.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/encode.go
+++ b/pkg/rlp/encode.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/encode_test.go
+++ b/pkg/rlp/encode_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/encode_test.go
+++ b/pkg/rlp/encode_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/rlp.go
+++ b/pkg/rlp/rlp.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rlp/rlp.go
+++ b/pkg/rlp/rlp.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/backend.go
+++ b/pkg/rpcbackend/backend.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/backend_test.go
+++ b/pkg/rpcbackend/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/wsbackend.go
+++ b/pkg/rpcbackend/wsbackend.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/wsbackend_test.go
+++ b/pkg/rpcbackend/wsbackend_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rpcbackend/wsbackend_test.go
+++ b/pkg/rpcbackend/wsbackend_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/keypair.go
+++ b/pkg/secp256k1/keypair.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/keypair.go
+++ b/pkg/secp256k1/keypair.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/keypair_test.go
+++ b/pkg/secp256k1/keypair_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/keypair_test.go
+++ b/pkg/secp256k1/keypair_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/signer.go
+++ b/pkg/secp256k1/signer.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/signer.go
+++ b/pkg/secp256k1/signer.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/signer_test.go
+++ b/pkg/secp256k1/signer_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright @ 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/secp256k1/signer_test.go
+++ b/pkg/secp256k1/signer_test.go
@@ -1,4 +1,4 @@
-// Copyright @ 2024 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
# Problem

We need to consistently build and push to a public ECR repo so that we can consume from Oracle Cloud.

# Solution

1. Created an OIDC connect from Github Actions to AWS Dev environment
2. Created a github action to use the OIDC connector to authenticate and push to a public ECR repo
3. Had to fix a bunch of linting errors around copyright headers. El strangeo.

**NOTE** We will need to update the affected branch in the github action to enable CICD. I just didn't know which branch that was going to be.